### PR TITLE
fixed README.md formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ BCR heavy (IgH) and light (Igk/IgL) chains.
 
 V'DJer accepts a sorted and indexed BAM file mapped to hg38 as input.  We currently
 use STAR for alignment.  At the end of a run assembled contigs will appear in
-```vdj_contigs.fa``` and reads aligned to those contigs are written to ```stdout```
+`vdj_contigs.fa` and reads aligned to those contigs are written to `stdout`
 
 The V'DJer output is suitable for use by downstream quantification tools such as [RSEM](http://deweylab.github.io/RSEM/).
 
@@ -16,8 +16,8 @@ The V'DJer output is suitable for use by downstream quantification tools such as
 
 Use a recent release: https://github.com/mozack/vdjer/releases
 
-To compile, just cd into the vdjer directory and type ```make```.  An executable named
-```vdjer``` will be created.
+To compile, just cd into the vdjer directory and type `make`.  An executable named
+`vdjer` will be created.
 
 To date, V'DJer has been tested only on linux systems.
 
@@ -33,14 +33,16 @@ V'DJer operates on paired end reads.  Single end reads are not currently support
 When mapping with STAR, unmapped reads must be included in the BAM file (this is not 
 STAR's default behavior).  Include the unmapped reads using the following param:
 
-```--outSAMunmapped Within```
+`--outSAMunmapped Within`
 
 Be sure to sort and index the BAM file.
 
 The following runs vdjer on the input star.sort.bam file with vdj_contigs.fa
 generated in the current working directory and read alignments written to vdjer.sam:
 
-```vdjer --in star.sort.bam --t 8 --ins 175 --chain IGH --ref-dir vdjer_human_references/igh > vdjer.sam 2> vdjer.log```
+```
+vdjer --in star.sort.bam --t 8 --ins 175 --chain IGH --ref-dir vdjer_human_references/igh > vdjer.sam 2> vdjer.log
+```
 
 The above runs on the IgH chain with read length of 50, 8 threads and median insert length of 175.
 
@@ -59,8 +61,10 @@ In cases where a sample has low BCR expression levels, one may opt to run V'DJer
 Running sensitive mode on samples with abundant BCR expression levels may result in extremely high computational costs.
 Example command:
 
-```vdjer --in star.sort.bam --t 8 --ins 175 --chain IGH --ref-dir vdjer_human_references/igh --k 25 
---mq 60 --mf 2 --rs 25 --ms 2 --mcs -5.5 > vdjer.sam 2> vdjer.log ```
+```
+vdjer --in star.sort.bam --t 8 --ins 175 --chain IGH --ref-dir vdjer_human_references/igh --k 25 
+--mq 60 --mf 2 --rs 25 --ms 2 --mcs -5.5 > vdjer.sam 2> vdjer.log 
+```
 
 Decreasing mq and mf from the defaults results in less aggressive graph pruning.
 Reducing rs and ms results in less aggressive coverage based filtering


### PR DESCRIPTION
The Markdown formatting in the README.md did not render some of the example command lines correctly.  